### PR TITLE
Makefile: Fix missing symbols in kernel starting from 4.20

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -89,7 +89,7 @@ ibanner:
 
 obj-m := rcraid.o
 
-rcraid-objs := rc_init.o rc_msg.o rc_mem_ops.o rc_event.o rc_config.o rcblob.${PLATFORM} \
+rcraid-objs := rc_init.o rc_msg.o rc_mem_ops.o rc_event.o rc_config.o rcblob.${PLATFORM}.o \
 	       vers.o
 
 .PHONY:	$(obj)/vers.c
@@ -98,6 +98,7 @@ $(obj)/vers.c:
 
 # hack to avoid warning about missing .rcblob.cmd file when modpost tries to
 # find all the sources
-.PHONY: $(obj)/rcblob.${PLATFORM}
-$(obj)/rcblob.${PLATFORM}:
+.PHONY: $(obj)/rcblob.${PLATFORM}.o
+$(obj)/rcblob.${PLATFORM}.o:
+	ln -sf `basename $@ .o` $@
 	@( echo "cmd_$@ := true"; echo "dep_$@ := \\"; echo "	$@ \\"; echo "" ) > $(obj)/.`basename $@`.cmd

--- a/src/rc_adapter.h
+++ b/src/rc_adapter.h
@@ -40,7 +40,9 @@ typedef int (* rc_adapter_func_t)(struct rc_adapter_s *adapter);
 #define MAX_HBA             8
 #define MAX_TOTAL_PORTS     (MAX_HBA * MAX_PORTS_PER_HA)
 #define MAX_ARRAY           32
+#ifndef SECTOR_SIZE
 #define SECTOR_SIZE         512
+#endif
 
 #define PCI_CFG_SIZE    256
 typedef struct rc_hw_info {


### PR DESCRIPTION
Due to changes to the kernel build system, the rcblob was not picked up in the
linking stage, leading to missing symbols in the rcraid.ko kernel module.
Fixed by changing Makefile destinations and rules.

Credit for this fix goes to @martinkarlweber.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>