### PR TITLE
Fix build issue

### DIFF
--- a/src/rc_init.c
+++ b/src/rc_init.c
@@ -165,7 +165,7 @@ static int  rc_eh_bus_reset(struct scsi_cmnd * scmd);
 static int  rc_eh_hba_reset(struct scsi_cmnd * scmd);
 
 void        rc_shutdown_adapter(rc_adapter_t *adapter);
-int         rc_ioctl(struct scsi_device * scsi_dev_ptr, int cmd, void *arg);
+int         rc_ioctl(struct scsi_device * scsi_dev_ptr, unsigned int cmd, void *arg);
 void        rc_dump_scp(struct scsi_cmnd * scp);
 const char *rc_info(struct Scsi_Host *host_ptr);
 void        rc_timeout(int to);
@@ -1970,7 +1970,7 @@ rc_slave_cfg(struct scsi_device *sdev)
 
 int
 rc_ioctl (struct scsi_device * scsi_dev_ptr,
-	  int cmd,
+	  unsigned int cmd,
 	  void *arg)
 {
 	char direction = 'w';


### PR DESCRIPTION
Fixes this particular error that stops the build
`rcraid-dkms/src/rc_init.c:335:29: error: initialization of ‘int (*)(struct scsi_device *, unsigned int,  void *)’ from incompatible pointer type ‘int (*)(struct scsi_device *, int,  void *)’ [-Werror=incompatible-pointer-types]
  335 |  .ioctl =                   rc_ioctl,
      |                             ^~~~~~~~
`
Built on Ubuntu 19.10 kernel 5.3.0-13-generic on x570 board and works perfectly so far.