### PR TITLE
Changed uname flag from -i to -m

### DIFF
--- a/arch/.SRCINFO
+++ b/arch/.SRCINFO
@@ -1,0 +1,14 @@
+pkgbase = rcraid-dkms
+	pkgdesc = AMD AM4 socket X370/X470 chipset motherbroad NVMe/SATA RAID driver (DKMS)
+	pkgver = 17.2.1
+	pkgrel = 1
+	url = https://www.amd.com/en/support/chipsets/amd-socket-am4/x370
+	arch = i686
+	arch = x86_64
+	license = GPL2
+	makedepends = linux-headers>=4.15
+	depends = dkms
+	source = dkms.conf
+	md5sums = 3a14dcc84daf257a62727bcde1882edf
+pkgname = rcraid-dkms
+

--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: foo <foo(at)example(dot)org>
+# Contributor: bar <bar(at)example(dot)org>
+
+_pkgbase=rcraid
+pkgname=rcraid-dkms
+pkgver=17.2.1
+pkgrel=2
+pkgdesc="AMD AM4 socket X370/X470 chipset motherbroad NVMe/SATA RAID driver (DKMS)"
+arch=('i686' 'x86_64')
+url="https://www.amd.com/en/support/chipsets/amd-socket-am4/x370"
+license=('GPL2')
+depends=('dkms')
+makedepends=('linux-headers>=4.15')
+source=('dkms.conf')
+md5sums=('3a14dcc84daf257a62727bcde1882edf')
+
+prepare()
+{
+  cp -r "${startdir}"/../src/* "${srcdir}"
+}
+
+build() {
+  cd ${srcdir}
+  make
+}
+
+package() {
+  # Copy dkms.conf
+  install -Dm644 "${startdir}"/dkms.conf "${pkgdir}"/usr/src/${_pkgbase}-${pkgver}/dkms.conf
+
+  # Set name and version
+  sed -e "s/@_PKGBASE@/${_pkgbase}/" \
+      -e "s/@PKGVER@/${pkgver}/" \
+      -i "${pkgdir}"/usr/src/${_pkgbase}-${pkgver}/dkms.conf
+
+
+if [ "$KVERS" == "" ]; then
+  KVERS=$(uname -r)
+fi
+  install -Dm644 rcraid.ko "${pkgdir}"/usr/lib/modules/$(echo -n $KVERS)/kernel/drivers/scsi/rcraid.ko
+
+  make clean
+  rm dkms.conf
+  rm rcraid.mod
+  cp -r * "${pkgdir}"/usr/src/${_pkgbase}-${pkgver}/
+}

--- a/arch/README.md
+++ b/arch/README.md
@@ -1,0 +1,36 @@
+Installation on Arch/Manjaro:
+
+Download and unpack zip or "git clone https://github.com/misiektw/rcraid-dkms.git"
+
+From inside "arch" directory:
+
+  makepkg -si
+  
+This will compile sources and install package for current running kernel. If you need 
+to make package for different kernel then you can use KVERS option.
+After installing edit /etc/mkinitcpio.conf and add
+  
+  MODULES=(rcraid?)
+
+then rebuild your initrd f.e.:
+
+  mkinitcpio -p linux54
+
+Sources for this install were forked from https://github.com/thopiekar/rcraid-dkms
+I left original debian folder as im using many distros and its handy.
+
+Note: If you just planning on switching to rcraid, my advice is: don't. 
+Support from AMD for Promontory raid on Linux is pretty much non-existent. 
+You will be way better off sticking with mdadm, zfs or lvm. 
+
+If you REALLY want this to dual-boot Linux/Win, also don't. Setting up virtualization 
+with KVM with GPU Passtrough today is really simple, and you will not need to 
+boot Windows directly on your hardware ever again.
+
+Sidenote: If you decide to use rcraid regardless you might want to also install RAIDXpert. 
+Web interface isn't working properly on Manjaro, but rcadm is more or less is.
+
+Sidenote2: If you ever decide to switch from rcraid to something else, you may find it useful 
+to know that deleting arrays only removes metadata. Partitions are still there, and can be
+recovered with gdisk, gpart etc. I found out that offset for partitions is 1069056 sectors (512B).
+So if you have partition starting at usual 2048 it will be at 1071104 after array deletion.

--- a/arch/dkms.conf
+++ b/arch/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="@_PKGBASE@"
+PACKAGE_VERSION="@PKGVER@"
+MAKE[0]="make KVERS=$kernelver"
+CLEAN="make clean"
+BUILT_MODULE_NAME[0]="@_PKGBASE@"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/scsi"
+AUTOINSTALL="yes"

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ RC_HOST=$(shell /bin/hostname)
 RC_USER=$(shell whoami)
 RC_DATE=$(shell /bin/date)
 RC_BUILD_DATE=$(shell /bin/date +'%b %d %Y')
-PLATFORM=$(shell uname -i)
+PLATFORM=$(shell uname -m)
 
 EXTRA_CFLAGS += -D__LINUX__
 EXTRA_CFLAGS += -DRC_AHCI_SUPPORT -DRC_AMD_AHCI -DRC_AHCI_AUTOSENSE


### PR DESCRIPTION
$PLATFORM should be x86_64 or i386 for correct rcblob file. But on most distros 'uname -i' returns "unknown". Meanwhile 'uname -m' almost always returns correct string.
sources:
Man page says '-i' flag is ambiguous, it can return "hardware platform or "unknown"". https://linux.die.net/man/1/uname
Wiki uname page list very few systems returning correct string (f.e..Ubuntu): https://en.wikipedia.org/wiki/Uname

Also I just checked Debian, Arch, Manjaro and they all return "unknown". Slackware returns processor type "GenuineIntel". 
