### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Foreword:
 ===========
 
 Many AMD mainboards for the AM4 socket based on the following chipsets come with RAID support:
+ * A320
  * X370
  * X399
  * X470


### PR DESCRIPTION
 * Append `modprobe.blacklist=ahci` to GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub
I had problem with external HDD, in A320 chipset, and I removed this line and works fine, both AMD Raid and Extrenal Hdd