### PR TITLE
Fix compile for `5.15.6-200.fc35.x86_64`

### DIFF
--- a/.github/workflows/rcraid-dkms-ci.yml
+++ b/.github/workflows/rcraid-dkms-ci.yml
@@ -1,0 +1,42 @@
+name: rcraid-dkms-ci
+on:
+  - push
+  - pull_request
+defaults:
+  run:
+    shell: bash
+jobs:
+  rcraid-dkms-ci-job:
+    env:
+      TERM: 'xterm-256color'
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-18.04
+          - ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    name: ${{ github.event.repository.name }}_${{ matrix.os }}
+    steps:
+      - name: ${{ github.event.repository.name }}_${{ matrix.os }}_checkout
+        uses: actions/checkout@v2
+
+      - name: ${{ github.event.repository.name }}_${{ matrix.os }}_environment_details
+        run: |
+          uname -r
+          uname -a
+          cat /etc/os-release
+          ls -1 /lib/modules/
+
+      - name: ${{ github.event.repository.name }}_${{ matrix.os }}_install_build_depdencies
+        run: |
+          sudo apt install -y --no-install-recommends make linux-headers-generic
+
+      - name: ${{ github.event.repository.name }}_${{ matrix.os }}_make
+        run: |
+          cd src
+          echo
+          ls -1 /lib/modules/
+          echo
+          export KVERS="$(ls -1 /lib/modules/ | tail -n1)"
+          make

--- a/src/rc_msg.c
+++ b/src/rc_msg.c
@@ -1466,10 +1466,12 @@ rc_msg_send_srb(struct scsi_cmnd * scp)
 	srb->scsi_context = scp;
 	srb->sg_list      = (rc_sg_list_t *)&srb->private32[0];
 	srb->dev_private  = (char *)srb->sg_list + sg_list_size;
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,26)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0))
+	srb->timeout      = scsi_cmd_to_rq(scp)->timeout/HZ;
+#elif (LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,26))
 	srb->timeout      = scp->timeout_per_command/HZ;
 #else
-	srb->timeout      = scsi_cmd_to_rq(scp)->timeout/HZ;
+	srb->timeout      = scp->request->timeout/HZ;
 #endif
 	srb->seq_num      = rc_srb_seq_num++;
 

--- a/src/rc_msg.c
+++ b/src/rc_msg.c
@@ -25,6 +25,7 @@
 #include "asm/msr.h"
 #include <linux/page-flags.h>
 #include <linux/vmalloc.h>
+#include <scsi/sg.h>
 #include "rc_ahci.h"
 
 int  rc_setup_communications(void);
@@ -1468,7 +1469,7 @@ rc_msg_send_srb(struct scsi_cmnd * scp)
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,26)
 	srb->timeout      = scp->timeout_per_command/HZ;
 #else
-	srb->timeout      = scp->request->timeout/HZ;
+	srb->timeout      = scsi_cmd_to_rq(scp)->timeout/HZ;
 #endif
 	srb->seq_num      = rc_srb_seq_num++;
 


### PR DESCRIPTION
* `#include <scsi/sg.h>` is needed for newer Kernel.
* `scp->request` has been removed and `scsi_cmd_to_rq(scp)` should be used instead.

---

Before:

```sh
$ cd src
$ make
make -C /lib/modules/5.15.6-200.fc35.x86_64/build M=/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src
make[1]: Entering directory '/usr/src/kernels/5.15.6-200.fc35.x86_64'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (GCC) 11.2.1 20210728 (Red Hat 11.2.1-1)
  You are using:           gcc (GCC) 11.2.1 20211203 (Red Hat 11.2.1-7)
ln -sf `basename /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rcblob.x86_64.o .o` /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rcblob.x86_64.o
  CC [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_init.o
/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_init.c: In function ‘rcraid_resume_one’:
/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_init.c:1105:9: warning: ignoring return value of ‘pci_enable_device’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 1105 |         pci_enable_device(adapter->pdev);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_init.c:1130:5: warning: ignoring return value of ‘pcim_enable_device’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 1130 |     pcim_enable_device(pdev);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
  CC [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_msg.o
/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_msg.c: In function ‘rc_msg_send_srb’:
/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_msg.c:1471:32: error: ‘struct scsi_cmnd’ has no member named ‘request’
 1471 |         srb->timeout      = scp->request->timeout/HZ;
      |                                ^~
/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_msg.c: In function ‘rc_msg_srb_complete’:
/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_msg.c:1873:70: error: ‘GOOD’ undeclared (first use in this function)
 1873 |                 scp->result = DID_OK << 16 | COMMAND_COMPLETE << 8 | GOOD;
      |                                                                      ^~~~
/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_msg.c:1873:70: note: each undeclared identifier is reported only once for each function it appears in
/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_msg.c:1913:62: error: ‘CHECK_CONDITION’ undeclared (first use in this function)
 1913 |         scp->result = DID_OK << 16 | COMMAND_COMPLETE << 8 | CHECK_CONDITION;
      |                                                              ^~~~~~~~~~~~~~~
make[2]: *** [scripts/Makefile.build:277: /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_msg.o] Error 1
make[1]: *** [Makefile:1872: /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src] Error 2
make[1]: Leaving directory '/usr/src/kernels/5.15.6-200.fc35.x86_64'
make: *** [Makefile:68: module] Error 2
```

After:

```sh
$ cd src
$ make
make -C /lib/modules/5.15.6-200.fc35.x86_64/build M=/run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src
make[1]: Entering directory '/usr/src/kernels/5.15.6-200.fc35.x86_64'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (GCC) 11.2.1 20210728 (Red Hat 11.2.1-1)
  You are using:           gcc (GCC) 11.2.1 20211203 (Red Hat 11.2.1-7)
ln -sf `basename /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rcblob.x86_64.o .o` /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rcblob.x86_64.o
  CC [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_msg.o
  CC [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_mem_ops.o
  CC [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_event.o
  CC [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rc_config.o
  CC [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/vers.o
  LD [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rcraid.o
  MODPOST /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/Module.symvers
  CC [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rcraid.mod.o
  LD [M]  /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rcraid.ko
  BTF [M] /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rcraid.ko
Skipping BTF generation for /run/media/mbana/sabrent_rocket_q4/@/dev/github/banaio/rcraid-dkms/src/rcraid.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/kernels/5.15.6-200.fc35.x86_64'
```