### PR TITLE
Update to kernel 5.17 and 5.18

### DIFF
--- a/src/rc_config.c
+++ b/src/rc_config.c
@@ -4,11 +4,11 @@
  *
  ****************************************************************************/
 
+#include <linux/version.h>
 
 #include <linux/module.h>
 #include <linux/fs.h>
 #include <linux/miscdevice.h>
-#include <linux/genhd.h>
 #include <linux/sched.h>
 #include <linux/completion.h>
 
@@ -26,6 +26,10 @@
 #include "rc_scsi.h"
 #include "rc_msg_platform.h"
 #include "rc_adapter.h"
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
+#include <linux/genhd.h>
+#endif
 
 #ifndef GFP_NOWAIT
 #define GFP_NOWAIT	(GFP_ATOMIC & ~__GFP_HIGH)

--- a/src/rc_init.c
+++ b/src/rc_init.c
@@ -39,6 +39,7 @@
 #include "version.h"
 #include "build_number.h"
 #include "rc_pci_ids.h"
+#include <linux/version.h>
 #include <linux/hdreg.h>
 #include <linux/reboot.h>
 #include <linux/pci.h>
@@ -48,6 +49,10 @@
 #include <linux/spinlock_types.h>
 #include <linux/sysctl.h>
 #include <linux/pm_runtime.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#include <linux/dma-mapping.h>
+#endif
 
 // FIXME: some older kernels still supported by RAIDCore do not have
 //        DMA_BIT_MASK().  Remove once support for them has been dropped.
@@ -184,6 +189,8 @@ int         rc_bios_params(struct scsi_device *sdev, struct block_device *bdev,
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36)
 int         rc_queue_cmd(struct scsi_cmnd * scp, void (*CompletionRoutine) (struct scsi_cmnd *));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0)
+int         rc_queue_cmd_lck(struct scsi_cmnd * scp);
 #else
 int         rc_queue_cmd_lck(struct scsi_cmnd * scp, void (*CompletionRoutine) (struct scsi_cmnd *));
 #endif
@@ -525,6 +532,7 @@ rc_init_adapter(struct pci_dev *dev, const struct pci_device_id *id)
 	/*
 	 * set dma_mask to 64 bit capabilities but if that fails, try 32 bit
 	 */
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
 	if (!pci_set_dma_mask(dev, DMA_BIT_MASK(64)) &&
 	    !pci_set_consistent_dma_mask(dev, DMA_BIT_MASK(64))) {
 		rc_printk(RC_NOTE, RC_DRIVER_NAME ": %s 64 bit DMA enabled\n",
@@ -539,6 +547,7 @@ rc_init_adapter(struct pci_dev *dev, const struct pci_device_id *id)
 		rc_shutdown_adapter(adapter);
 		return -ENODEV;
 	}
+	#endif
 
 	/*
 	 * map in the adapter MMIO space
@@ -905,10 +914,17 @@ rc_shutdown_adapter(rc_adapter_t *adapter)
 	rc_printk(RC_DEBUG, "%s: free private_mem 0x%p\n",
 		  __FUNCTION__, adapter->private_mem.vaddr);
 	if (adapter->private_mem.vaddr)  {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
 		pci_free_consistent(adapter->pdev,
 				    rc_state.memsize_per_controller,
 				    adapter->private_mem.vaddr,
 				    adapter->private_mem.dma_address);
+#else
+		dma_free_coherent(&adapter->pdev->dev, 
+					rc_state.memsize_per_controller, 
+					adapter->private_mem.vaddr,
+					adapter->private_mem.dma_address);
+#endif
 	}
 
 	/* pci_disable_device(adapter->pdev); */
@@ -1102,14 +1118,19 @@ static int rcraid_resume_one(struct pci_dev *pdev)
 
         pci_restore_state(adapter->pdev);
 
-        pci_enable_device(adapter->pdev);
+        if (pci_enable_device(adapter->pdev) != -ENOMEM) {
+			if (adapter->version->start_func)
+			{
+				(*adapter->version->start_func)(adapter);
+			}
 
-        if (adapter->version->start_func)
-        {
-            (*adapter->version->start_func)(adapter);
-        }
-
-        state->adapter_is_suspended &= ~(1 << adapter->instance);
+			state->adapter_is_suspended &= ~(1 << adapter->instance);
+		}
+		else
+		{
+			rc_printk(RC_NOTE, RC_DRIVER_NAME ": Failed to enable pdev %p\n",
+		  		adapter->pdev);
+		}
     }
 
     //
@@ -1127,29 +1148,33 @@ static int rcraid_resume_one(struct pci_dev *pdev)
 
 	pci_restore_state(pdev);
 
-    pcim_enable_device(pdev);
+    if (pcim_enable_device(pdev) != -ENOMEM){
+		//
+		// and restart the core...
+		//
+		if (adapter->version->start_func)
+		{
+			(*adapter->version->start_func)(adapter);
+		}
 
-    //
-    // and restart the core...
-    //
-    if (adapter->version->start_func)
-    {
-		(*adapter->version->start_func)(adapter);
-    }
+		rc_msg_init_tasklets(state);
 
-    rc_msg_init_tasklets(state);
+		rc_start_all_threads();
 
-    rc_start_all_threads();
+		rc_event_init();
 
-    rc_event_init();
+		schedule_delayed_work(&state->resume_work,250);
 
-    schedule_delayed_work(&state->resume_work,250);
+		scsi_unblock_requests(rc_state.host_ptr);
 
-    scsi_unblock_requests(rc_state.host_ptr);
+		state->adapter_is_suspended &= ~(1 << adapter->instance);
 
-    state->adapter_is_suspended &= ~(1 << adapter->instance);
-
-    return 0;
+		return 0;
+	} else {
+		rc_printk(RC_NOTE, RC_DRIVER_NAME ": Failed to enable pdev %p\n",
+		  		adapter->pdev);
+		return -1;
+	}
 }
 #endif  /* CONFIG_PM */
 
@@ -1389,12 +1414,16 @@ int rc_mpt2_shutdown(rc_adapter_t *adapter)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36)
 int rc_queue_cmd (struct scsi_cmnd * scp, void (*CompletionRoutine) (struct scsi_cmnd *))
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0)
+int rc_queue_cmd_lck(struct scsi_cmnd * scp);
 #else
 int rc_queue_cmd_lck (struct scsi_cmnd * scp, void (*CompletionRoutine) (struct scsi_cmnd *))
 #endif
 
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,16,0)
 	scp->scsi_done = CompletionRoutine;
+#endif
 	//#define FAIL_ALL_IO 0
 
 #ifdef FAIL_ALL_IO
@@ -1430,13 +1459,24 @@ rc_eh_abort_cmd (struct scsi_cmnd * scp)
 		  scp, scp->device->channel, scp->device->id);
 	// rc_config_debug = 1;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))
 	srb = (rc_srb_t *)scp->SCp.ptr;
+#else
+	srb = (rc_srb_t *)scp->host_scribble;
+#endif
+
 	if (srb != NULL) {
 		rc_printk(RC_DEBUG, "\tsrb: 0x%p seq_num %d function %x status %x "
 			  "flags %x b/t/l %d/%d/%d\n", srb, srb->seq_num, srb->function,
 			  srb->status, srb->flags, srb->bus, srb->target, srb->lun);
 		srb->scsi_context = NULL;
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))
 		scp->SCp.ptr = NULL;
+#else
+		scp->host_scribble = NULL;
+#endif
+
 	} else {
 		rc_printk(RC_WARN, "rc_eh_abort_cmd: srb already completed\n");
 		// most likely here because we already processed srb

--- a/src/rc_init.c
+++ b/src/rc_init.c
@@ -1415,7 +1415,7 @@ int rc_mpt2_shutdown(rc_adapter_t *adapter)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36)
 int rc_queue_cmd (struct scsi_cmnd * scp, void (*CompletionRoutine) (struct scsi_cmnd *))
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0)
-int rc_queue_cmd_lck(struct scsi_cmnd * scp);
+int rc_queue_cmd_lck(struct scsi_cmnd * scp)
 #else
 int rc_queue_cmd_lck (struct scsi_cmnd * scp, void (*CompletionRoutine) (struct scsi_cmnd *))
 #endif

--- a/src/rc_msg.c
+++ b/src/rc_msg.c
@@ -1495,7 +1495,7 @@ rc_msg_send_srb(struct scsi_cmnd * scp)
 	/* the scsi_cmnd pointer points at our srb, at least until the command is
 	 * aborted
 	 */
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0))
 	scp->SCp.ptr = (void *)srb;
 #else
 	scp->host_scribble = (void *)srb;
@@ -1889,7 +1889,7 @@ rc_msg_srb_complete(struct rc_srb_s *srb)
 		return;
 	}
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0))
 	scp->SCp.ptr = NULL;
 #else
 	scp->host_scribble = NULL;

--- a/src/rc_msg_platform.h
+++ b/src/rc_msg_platform.h
@@ -27,7 +27,7 @@
 #define RC_STHEXT_REDO_STRICT_TYPES
 #endif //int
 
-#include <stdarg.h>
+#include <linux/stdarg.h>
 
 #ifdef RC_STHEXT_REDO_STRICT_TYPES
 #define int Cannot_USE_int_because_it_is_ambiguous


### PR DESCRIPTION
- genhd.h header got removed as of kernel 5.18.
- The sci_cmd interface has changed. The done variable became a method as of 5.16. Furthermore as of 5.18 the SCp scratchpad has been removed. https://elixir.bootlin.com/linux/v5.18.5/source/include/scsi/scsi_cmnd.h
- Multiple pci methods have been removed and so I replaced them where it made sense with what they used to do which was mostly calling dma methods.

I have tested this on Fedora with kernerls 5.17.14-300.fc36.x86_64 and 5.18.5-200.fc36.x86_64