### PR TITLE
Arch install: add support for alternative (official) kernels

### DIFF
--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -10,7 +10,10 @@ arch=('i686' 'x86_64')
 url="https://www.amd.com/en/support/chipsets/amd-socket-am4/x370"
 license=('GPL2')
 depends=('dkms')
-makedepends=('linux-headers>=4.15')
+optdepends=('linux-headers>=4.15: build modules against the Arch kernel'
+            'linux-lts-headers>=4.15: build modules against the LTS kernel'
+            'linux-zen-headers>=4.15: build modules against the ZEN kernel'
+            'linux-hardened-headers>=4.15: build modules against the HARDENED kernel')
 source=('dkms.conf')
 md5sums=('3a14dcc84daf257a62727bcde1882edf')
 


### PR DESCRIPTION
As the title says. Otherwise it requires me to install `linux-headers` on Zen kernel (when I already have `linux-zen-headers` installed).
Copied from https://github.com/archlinux/svntogit-packages/blob/packages/dkms/trunk/PKGBUILD (plus version restriction).

I'm not sure if this is the correct way, but I don't see something like `optmakedepends` anywhere.
https://wiki.archlinux.org/title/PKGBUILD#makedepends - `If the software works on multiple alternative dependencies, all of them can be listed here, instead of the depends array. `