### PR TITLE
update version string

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,8 +1,7 @@
 #!/usr/bin/make -f
 #export DH_VERBOSE = 1
 
-VERSION ?= $(shell dpkg-parsechangelog |\
-	     sed -rne 's/^Version: ([0-9.]+)[-+].*$$/\1/p')
+VERSION ?= $(shell dpkg-parsechangelog --show-field Version)
 
 %:
 	dh $@


### PR DESCRIPTION
Without this patch, dkms source ends up in folder /usr/src/rcraid- and dkms.conf in folder /usr/src/rcraid-8.1.0. Tested on debian bullseye (during "normal" dpkg-buildpackage" process).